### PR TITLE
Fixed is_strict def.

### DIFF
--- a/lib/Syntax/Keyword/Assert.xs
+++ b/lib/Syntax/Keyword/Assert.xs
@@ -5,7 +5,7 @@
 
 #include "XSParseKeyword.h"
 
-static bool is_strict(pTHX_)
+static bool is_strict(pTHX)
 {
     dSP;
 
@@ -39,7 +39,7 @@ static OP *make_xcroak(pTHX_ OP *msg)
 
 static int build_assert(pTHX_ OP **out, XSParseKeywordPiece *arg0, void *hookdata)
 {
-    if (is_strict(aTHX_)) {
+    if (is_strict(aTHX)) {
         // build the following code:
         //
         //   Syntax::Keyword::Assert::_croak "Assertion failed"


### PR DESCRIPTION
This pull request fixed the following error:

> lib/Syntax/Keyword/Assert.xs:8:28: error: expected declaration specifiers or '...' before ')' token
>    8 | static bool is_strict(pTHX_)
>      |                            ^