### PR TITLE
Change strict mode.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -23,7 +23,6 @@ my %args = (
     },
 
     requires => {
-        'Devel::StrictMode' => '0.003',
         'XS::Parse::Keyword' => '0.36',
         'perl' => '5.016000',
     },

--- a/META.json
+++ b/META.json
@@ -43,7 +43,6 @@
       },
       "runtime" : {
          "requires" : {
-            "Devel::StrictMode" : "0.003",
             "XS::Parse::Keyword" : "0.36",
             "perl" : "5.016000"
          }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Syntax::Keyword::Assert introduces a lightweight assert keyword to Perl, designe
 
 - **STRICT Mode**
 
-    When STRICT mode is enabled, assert statements are checked at runtime. If the assertion fails (i.e., the block returns false), the program dies with an error. This is particularly useful for catching errors during development or testing.
+    When STRICT mode is enabled, assert statements are checked at runtime. Default is enabled. If the assertion fails (i.e., the block returns false), the program dies with an error. This is particularly useful for catching errors during development or testing.
 
 - **Zero Runtime Cost**
 
@@ -35,26 +35,14 @@ Syntax::Keyword::Assert introduces a lightweight assert keyword to Perl, designe
 
 ## STRICT Mode Control
 
-The behavior of STRICT mode is controlled by the [Devel::StrictMode](https://metacpan.org/pod/Devel%3A%3AStrictMode) module. You can enable or disable STRICT mode depending on your environment (e.g., development, testing, production).
-
-For example, to enable STRICT mode:
+If `$ENV{PERL_ASSERT_ENABLED}` is trusy, STRICT mode is enabled. Otherwise, it is disabled. Default is enabled.
 
 ```perl
-BEGIN { $ENV{PERL_STRICT} = 1 }  # Enable STRICT mode
+BEGIN { $ENV{PERL_ASSERT_ENABLED} = 0 }  # Disable STRICT mode
 
 use Syntax::Keyword::Assert;
-use Devel::StrictMode;
 
 assert { 1 == 1 };  # Always passes
-assert { 0 == 1 };  # Dies if STRICT mode is enabled
-```
-
-To disable STRICT mode (it is disabled by default):
-
-```perl
-use Syntax::Keyword::Assert;
-use Devel::StrictMode;
-
 assert { 0 == 1 };  # Block is ignored, no runtime cost
 ```
 

--- a/bench/compare-no-assertion.pl
+++ b/bench/compare-no-assertion.pl
@@ -21,11 +21,7 @@ use v5.40;
 use Benchmark qw(cmpthese);
 
 BEGIN {
-    # Disable STRICT mode. SEE ALSO: Devel::StrictMode
-    $ENV{EXTENDED_TESTING} = 0;
-    $ENV{AUTHOR_TESTING}   = 0;
-    $ENV{RELEASE_TESTING}  = 0;
-    $ENV{PERL_STRICT}      = 0;
+    $ENV{PERL_ASSERT_ENABLED} = 0;
 }
 
 use Syntax::Keyword::Assert;

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,5 @@
 requires 'perl', '5.016000';
 requires 'XS::Parse::Keyword' => '0.36';
-requires 'Devel::StrictMode', => '0.003';
 
 on 'configure' => sub {
   requires 'Module::Build' => '0.4004';

--- a/lib/Syntax/Keyword/Assert.pm
+++ b/lib/Syntax/Keyword/Assert.pm
@@ -4,7 +4,6 @@ use v5.14;
 use warnings;
 
 use Carp ();
-use Devel::StrictMode;
 
 require XSLoader;
 XSLoader::load( __PACKAGE__, our $VERSION );
@@ -72,7 +71,7 @@ Syntax::Keyword::Assert introduces a lightweight assert keyword to Perl, designe
 
 =item B<STRICT Mode>
 
-When STRICT mode is enabled, assert statements are checked at runtime. If the assertion fails (i.e., the block returns false), the program dies with an error. This is particularly useful for catching errors during development or testing.
+When STRICT mode is enabled, assert statements are checked at runtime. Default is enabled. If the assertion fails (i.e., the block returns false), the program dies with an error. This is particularly useful for catching errors during development or testing.
 
 =item B<Zero Runtime Cost>
 
@@ -86,23 +85,13 @@ The syntax is straightforward—assert BLOCK—making it easy to integrate into 
 
 =head2 STRICT Mode Control
 
-The behavior of STRICT mode is controlled by the L<Devel::StrictMode> module. You can enable or disable STRICT mode depending on your environment (e.g., development, testing, production).
+If C<$ENV{PERL_ASSERT_ENABLED}> is trusy, STRICT mode is enabled. Otherwise, it is disabled. Default is enabled.
 
-For example, to enable STRICT mode:
-
-    BEGIN { $ENV{PERL_STRICT} = 1 }  # Enable STRICT mode
+    BEGIN { $ENV{PERL_ASSERT_ENABLED} = 0 }  # Disable STRICT mode
 
     use Syntax::Keyword::Assert;
-    use Devel::StrictMode;
 
     assert { 1 == 1 };  # Always passes
-    assert { 0 == 1 };  # Dies if STRICT mode is enabled
-
-To disable STRICT mode (it is disabled by default):
-
-    use Syntax::Keyword::Assert;
-    use Devel::StrictMode;
-
     assert { 0 == 1 };  # Block is ignored, no runtime cost
 
 SEE ALSO:

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -1,12 +1,8 @@
 use Test2::V0;
 
-BEGIN {
-    $ENV{PERL_STRICT} = 1;
-}
-
 use Syntax::Keyword::Assert;
 
-subtest 'Test `assert` keyword with STRICT enabled' => sub {
+subtest 'Test `assert` keyword' => sub {
     like dies {
         assert { 0 };
     }, qr/\AAssertion failed/;

--- a/t/02_assert_disabled.t
+++ b/t/02_assert_disabled.t
@@ -1,16 +1,12 @@
 use Test2::V0;
 
 BEGIN {
-    # Disable STRICT mode. SEE ALSO: Devel::StrictMode
-    $ENV{EXTENDED_TESTING} = 0;
-    $ENV{AUTHOR_TESTING}   = 0;
-    $ENV{RELEASE_TESTING}  = 0;
-    $ENV{PERL_STRICT}      = 0;
+    $ENV{PERL_ASSERT_ENABLED} = !!0
 }
 
 use Syntax::Keyword::Assert;
 
-subtest 'Test `assert` keyword with STRICT disabled' => sub {
+subtest 'Test `assert` keyword when $ENV{PERL_ASSERT_ENABLED} is falsy' => sub {
     ok lives {
         assert { 0 };
     };


### PR DESCRIPTION
This pull request aims to reduce dependencies and simply this module.

- Remove Devel::Strict
- Instead use $ENV{PERL_ASSERT_ENABLE}
- And change strict mode default. Default is enabled.

Reference implement: https://metacpan.org/release/PEVANS/Syntax-Keyword-Assert-0.01/source/lib/Syntax/Keyword/Assert.xs#L167