### PR TITLE
Improve error message and change assert syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Syntax::Keyword::Assert - assert keyword for Perl with zero runtime cost in prod
 use Syntax::Keyword::Assert;
 
 sub hello($name) {
-    assert { defined $name };
+    assert( defined $name );
     say "Hello, $name!";
 }
 
@@ -42,8 +42,8 @@ BEGIN { $ENV{PERL_ASSERT_ENABLED} = 0 }  # Disable STRICT mode
 
 use Syntax::Keyword::Assert;
 
-assert { 1 == 1 };  # Always passes
-assert { 0 == 1 };  # Block is ignored, no runtime cost
+assert ( 1 == 1 );  # Always passes
+assert ( 0 == 1 );  # Block is ignored, no runtime cost
 ```
 
 SEE ALSO:

--- a/README.md
+++ b/README.md
@@ -8,13 +8,9 @@ Syntax::Keyword::Assert - assert keyword for Perl with zero runtime cost in prod
 ```perl
 use Syntax::Keyword::Assert;
 
-sub hello($name) {
-    assert( defined $name );
-    say "Hello, $name!";
-}
-
-hello("Alice"); # => Hello, Alice!
-hello();        # => Dies when STRICT mode is enabled
+my $name = 'Alice';
+assert( $name eq 'Bob' );
+# => Assertion failed ("Alice" eq "Bob")
 ```
 
 # DESCRIPTION
@@ -25,45 +21,23 @@ Syntax::Keyword::Assert introduces a lightweight assert keyword to Perl, designe
 
     When STRICT mode is enabled, assert statements are checked at runtime. Default is enabled. If the assertion fails (i.e., the block returns false), the program dies with an error. This is particularly useful for catching errors during development or testing.
 
+    `$ENV{PERL_ASSERT_ENABLED}` can be used to control STRICT mode.
+
+    ```
+    BEGIN { $ENV{PERL_ASSERT_ENABLED} = 0 }  # Disable STRICT mode
+    ```
+
 - **Zero Runtime Cost**
 
     When STRICT mode is disabled, the assert blocks are completely ignored at compile phase, resulting in zero runtime cost. This makes Syntax::Keyword::Assert ideal for use in production environments, as it does not introduce any performance penalties when assertions are not needed.
 
 - **Simple Syntax**
 
-    The syntax is straightforward—assert BLOCK—making it easy to integrate into existing code.
+    The syntax is dead simple. Just use the assert keyword followed by a block that returns a boolean value.
 
-## STRICT Mode Control
-
-If `$ENV{PERL_ASSERT_ENABLED}` is trusy, STRICT mode is enabled. Otherwise, it is disabled. Default is enabled.
-
-```perl
-BEGIN { $ENV{PERL_ASSERT_ENABLED} = 0 }  # Disable STRICT mode
-
-use Syntax::Keyword::Assert;
-
-assert ( 1 == 1 );  # Always passes
-assert ( 0 == 1 );  # Block is ignored, no runtime cost
-```
-
-SEE ALSO:
-[Bench ](https://metacpan.org/pod/%20https%3A#github.com-kfly8-Syntax-Keyword-Assert-blob-main-bench-compare-no-assertion.pl)
-
-# TIPS
-
-## Verbose error messages
-
-If you set `$Carp::Verbose = 1`, you can see stack traces when an assertion fails.
-
-```perl
-use Syntax::Keyword::Assert;
-use Carp;
-
-assert {
-    local $Carp::Verbose = 1;
-    0;
-}
-```
+    ```
+    assert( $name eq 'Bob' );
+    ```
 
 # SEE ALSO
 

--- a/bench/compare-no-assertion.pl
+++ b/bench/compare-no-assertion.pl
@@ -28,7 +28,7 @@ use Syntax::Keyword::Assert;
 
 # Function with assertion block but it is ignored at runtime
 sub with_assertion($message) {
-    assert { defined $message };
+    assert( defined $message );
     return $message;
 }
 

--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -12,6 +12,7 @@ sub new {
 
     my @flags = @{ $build->extra_compiler_flags };
     push @flags, XS::Parse::Keyword::Builder->extra_compiler_flags;
+    push @flags, '-Ihax';
 
     $build->extra_compiler_flags( @flags );
 

--- a/hax/newUNOP_CUSTOM.c.inc
+++ b/hax/newUNOP_CUSTOM.c.inc
@@ -1,0 +1,22 @@
+/* Before perl 5.22 under -DDEBUGGING, various new*OP() functions throw assert
+ * failures on OP_CUSTOM.
+ *   https://rt.cpan.org/Ticket/Display.html?id=128562
+ */
+
+#define newUNOP_CUSTOM(func, flags, first) S_newUNOP_CUSTOM(aTHX_ func, flags, first)
+static OP *S_newUNOP_CUSTOM(pTHX_ OP *(*func)(pTHX), U32 flags, OP *first)
+{
+  UNOP *unop;
+#if HAVE_PERL_VERSION(5,22,0)
+  unop = (UNOP *)newUNOP(OP_CUSTOM, flags, first);
+#else
+  NewOp(1101, unop, 1, UNOP);
+  unop->op_type = (OPCODE)OP_CUSTOM;
+  unop->op_first = first;
+  unop->op_flags = (U8)(flags | OPf_KIDS);
+  unop->op_private = (U8)(1 | (flags >> 8));
+#endif
+  unop->op_ppaddr = func;
+  return (OP *)unop;
+}
+

--- a/hax/sv_numeq.c.inc
+++ b/hax/sv_numeq.c.inc
@@ -1,0 +1,67 @@
+/* vi: set ft=c : */
+#ifndef sv_numeq_flags
+#  define sv_numeq_flags(lhs, rhs, flags)  S_sv_numeq_flags(aTHX_ lhs, rhs, flags)
+static bool S_sv_numeq_flags(pTHX_ SV *lhs, SV *rhs, U32 flags)
+{
+  if(flags & SV_GMAGIC) {
+    if(lhs)
+      SvGETMAGIC(lhs);
+    if(rhs)
+      SvGETMAGIC(rhs);
+  }
+  if(!lhs)
+    lhs = &PL_sv_undef;
+  if(!rhs)
+    rhs = &PL_sv_undef;
+  if(!(flags & SV_SKIP_OVERLOAD) && (SvAMAGIC(lhs) || SvAMAGIC(rhs))) {
+    SV *ret = amagic_call(lhs, rhs, eq_amg, 0);
+    if(ret)
+      return SvTRUE(ret);
+  }
+  /* We'd like to call Perl_do_ncmp, except that isn't an exported API function
+   * Here's a near-copy of it for num-equality testing purposes */
+#ifndef HAVE_BOOL_SvIV_please_nomg
+  /* Before perl 5.18, SvIV_please_nomg() was void-returning */
+  SvIV_please_nomg(lhs);
+  SvIV_please_nomg(rhs);
+#endif
+  if(
+#ifdef HAVE_BOOL_SvIV_please_nomg
+    SvIV_please_nomg(rhs) && SvIV_please_nomg(lhs)
+#else
+    SvIOK(lhs) && SvIOK(rhs)
+#endif
+  ) {
+    /* Compare as integers */
+    switch((SvUOK(lhs) ? 1 : 0) | (SvUOK(rhs) ? 2 : 0)) {
+      case 0: /* IV == IV */
+        return SvIVX(lhs) == SvIVX(rhs);
+      case 1: /* UV == IV */
+      {
+        const IV riv = SvUVX(rhs);
+        if(riv < 0)
+          return 0;
+        return (SvUVX(lhs) == riv);
+      }
+      case 2: /* IV == UV */
+      {
+        const IV liv = SvUVX(lhs);
+        if(liv < 0)
+          return 0;
+        return (liv == SvUVX(rhs));
+      }
+      case 3: /* UV == UV */
+        return SvUVX(lhs) == SvUVX(rhs);
+    }
+  }
+  else {
+    /* Compare NVs */
+    NV const rnv = SvNV_nomg(rhs);
+    NV const lnv = SvNV_nomg(lhs);
+    return lnv == rnv;
+  }
+}
+#endif
+#ifndef sv_numeq
+#  define sv_numeq(lhs, rhs)  sv_numeq_flags(lhs, rhs, 0)
+#endif

--- a/hax/sv_streq.c.inc
+++ b/hax/sv_streq.c.inc
@@ -1,0 +1,26 @@
+/* vi: set ft=c : */
+#ifndef sv_streq_flags
+#  define sv_streq_flags(lhs, rhs, flags)  S_sv_streq_flags(aTHX_ lhs, rhs, flags)
+static bool S_sv_streq_flags(pTHX_ SV *lhs, SV *rhs, U32 flags)
+{
+  if(flags & SV_GMAGIC) {
+    if(lhs)
+      SvGETMAGIC(lhs);
+    if(rhs)
+      SvGETMAGIC(rhs);
+  }
+  if(!lhs)
+    lhs = &PL_sv_undef;
+  if(!rhs)
+    rhs = &PL_sv_undef;
+  if(!(flags & SV_SKIP_OVERLOAD) && (SvAMAGIC(lhs) || SvAMAGIC(rhs))) {
+    SV *ret = amagic_call(lhs, rhs, seq_amg, 0);
+    if(ret)
+      return SvTRUE(ret);
+  }
+  return sv_eq_flags(lhs, rhs, 0);
+}
+#endif
+#ifndef sv_streq
+#  define sv_streq(lhs, rhs)  sv_streq_flags(lhs, rhs, 0)
+#endif

--- a/lib/Syntax/Keyword/Assert.pm
+++ b/lib/Syntax/Keyword/Assert.pm
@@ -37,11 +37,6 @@ sub apply {
    Carp::croak "Unrecognised import symbols @{[ keys %syms ]}" if keys %syms;
 }
 
-# called from Assert.xs
-sub _croak {
-    goto &Carp::croak;
-}
-
 1;
 __END__
 

--- a/lib/Syntax/Keyword/Assert.pm
+++ b/lib/Syntax/Keyword/Assert.pm
@@ -56,7 +56,7 @@ Syntax::Keyword::Assert - assert keyword for Perl with zero runtime cost in prod
     use Syntax::Keyword::Assert;
 
     sub hello($name) {
-        assert { defined $name };
+        assert( defined $name );
         say "Hello, $name!";
     }
 
@@ -91,8 +91,8 @@ If C<$ENV{PERL_ASSERT_ENABLED}> is trusy, STRICT mode is enabled. Otherwise, it 
 
     use Syntax::Keyword::Assert;
 
-    assert { 1 == 1 };  # Always passes
-    assert { 0 == 1 };  # Block is ignored, no runtime cost
+    assert ( 1 == 1 );  # Always passes
+    assert ( 0 == 1 );  # Block is ignored, no runtime cost
 
 SEE ALSO:
 L<Bench | https://github.com/kfly8/Syntax-Keyword-Assert/blob/main/bench/compare-no-assertion.pl>

--- a/lib/Syntax/Keyword/Assert.pm
+++ b/lib/Syntax/Keyword/Assert.pm
@@ -50,13 +50,9 @@ Syntax::Keyword::Assert - assert keyword for Perl with zero runtime cost in prod
 
     use Syntax::Keyword::Assert;
 
-    sub hello($name) {
-        assert( defined $name );
-        say "Hello, $name!";
-    }
-
-    hello("Alice"); # => Hello, Alice!
-    hello();        # => Dies when STRICT mode is enabled
+    my $name = 'Alice';
+    assert( $name eq 'Bob' );
+    # => Assertion failed ("Alice" eq "Bob")
 
 =head1 DESCRIPTION
 
@@ -68,29 +64,21 @@ Syntax::Keyword::Assert introduces a lightweight assert keyword to Perl, designe
 
 When STRICT mode is enabled, assert statements are checked at runtime. Default is enabled. If the assertion fails (i.e., the block returns false), the program dies with an error. This is particularly useful for catching errors during development or testing.
 
+C<$ENV{PERL_ASSERT_ENABLED}> can be used to control STRICT mode.
+
+    BEGIN { $ENV{PERL_ASSERT_ENABLED} = 0 }  # Disable STRICT mode
+
 =item B<Zero Runtime Cost>
 
 When STRICT mode is disabled, the assert blocks are completely ignored at compile phase, resulting in zero runtime cost. This makes Syntax::Keyword::Assert ideal for use in production environments, as it does not introduce any performance penalties when assertions are not needed.
 
 =item B<Simple Syntax>
 
-The syntax is straightforward—assert BLOCK—making it easy to integrate into existing code.
+The syntax is dead simple. Just use the assert keyword followed by a block that returns a boolean value.
+
+    assert( $name eq 'Bob' );
 
 =back
-
-=head2 STRICT Mode Control
-
-If C<$ENV{PERL_ASSERT_ENABLED}> is trusy, STRICT mode is enabled. Otherwise, it is disabled. Default is enabled.
-
-    BEGIN { $ENV{PERL_ASSERT_ENABLED} = 0 }  # Disable STRICT mode
-
-    use Syntax::Keyword::Assert;
-
-    assert ( 1 == 1 );  # Always passes
-    assert ( 0 == 1 );  # Block is ignored, no runtime cost
-
-SEE ALSO:
-L<Bench | https://github.com/kfly8/Syntax-Keyword-Assert/blob/main/bench/compare-no-assertion.pl>
 
 =head1 SEE ALSO
 

--- a/lib/Syntax/Keyword/Assert.pm
+++ b/lib/Syntax/Keyword/Assert.pm
@@ -92,20 +92,6 @@ If C<$ENV{PERL_ASSERT_ENABLED}> is trusy, STRICT mode is enabled. Otherwise, it 
 SEE ALSO:
 L<Bench | https://github.com/kfly8/Syntax-Keyword-Assert/blob/main/bench/compare-no-assertion.pl>
 
-=head1 TIPS
-
-=head2 Verbose error messages
-
-If you set C<$Carp::Verbose = 1>, you can see stack traces when an assertion fails.
-
-    use Syntax::Keyword::Assert;
-    use Carp;
-
-    assert {
-        local $Carp::Verbose = 1;
-        0;
-    }
-
 =head1 SEE ALSO
 
 =over 4

--- a/lib/Syntax/Keyword/Assert.xs
+++ b/lib/Syntax/Keyword/Assert.xs
@@ -9,6 +9,8 @@
     (PERL_REVISION > (R) || (PERL_REVISION == (R) && (PERL_VERSION > (V) || (PERL_VERSION == (V) && (PERL_SUBVERSION >= (S))))))
 
 #include "newUNOP_CUSTOM.c.inc"
+#include "sv_numeq.c.inc"
+#include "sv_streq.c.inc"
 
 static bool assert_enabled = TRUE;
 

--- a/lib/Syntax/Keyword/Assert.xs
+++ b/lib/Syntax/Keyword/Assert.xs
@@ -22,6 +22,9 @@ static int build_assert(pTHX_ OP **out, XSParseKeywordPiece *arg0, void *hookdat
 {
     OP *argop = arg0->op;
     if (assert_enabled) {
+        // int optype = argop->op_type;
+        // printf("optype: %d\n", optype);
+
         // build the following code:
         //
         //   Syntax::Keyword::Assert::_croak "Assertion failed"
@@ -40,12 +43,12 @@ static int build_assert(pTHX_ OP **out, XSParseKeywordPiece *arg0, void *hookdat
         *out = newOP(OP_NULL, 0);
     }
 
-    return KEYWORD_PLUGIN_STMT;
+    return KEYWORD_PLUGIN_EXPR;
 }
 
 static const struct XSParseKeywordHooks hooks_assert = {
   .permit_hintkey = "Syntax::Keyword::Assert/assert",
-  .piece1 = XPK_BLOCK,
+  .piece1 = XPK_TERMEXPR_SCALARCTX,
   .build1 = &build_assert,
 };
 

--- a/lib/Syntax/Keyword/Assert.xs
+++ b/lib/Syntax/Keyword/Assert.xs
@@ -25,11 +25,65 @@ static OP *pp_assert(pTHX)
   croak_sv(msg);
 }
 
+enum BinopType {
+    BINOP_NONE,
+    BINOP_NUMEQ,
+    BINOP_STREQ,
+};
+
+static enum BinopType classify_binop(int type)
+{
+  switch(type) {
+    case OP_EQ:  return BINOP_NUMEQ;
+    case OP_SEQ: return BINOP_STREQ;
+  }
+  return BINOP_NONE;
+}
+
+static XOP xop_assertbin;
+static OP *pp_assertbin(pTHX)
+{
+  dSP;
+  SV *rhs = POPs;
+  SV *lhs = POPs;
+  enum BinopType binoptype = PL_op->op_private;
+
+  switch(binoptype) {
+    case BINOP_NUMEQ:
+      if(sv_numeq(lhs, rhs))
+        goto ok;
+      break;
+
+    case BINOP_STREQ:
+      if(sv_streq(lhs, rhs))
+        goto ok;
+      break;
+
+    default:
+      croak("ARGH unreachable");
+  }
+
+  SV *msg = sv_2mortal(newSVpvs("Assertion failed"));
+  croak_sv(msg);
+
+ok:
+  RETURN;
+}
+
 static int build_assert(pTHX_ OP **out, XSParseKeywordPiece *arg0, void *hookdata)
 {
     OP *argop = arg0->op;
     if (assert_enabled) {
-        *out = newUNOP_CUSTOM(&pp_assert, 0, argop);
+        enum BinopType binoptype = classify_binop(argop->op_type);
+        if (binoptype) {
+            argop->op_type = OP_CUSTOM;
+            argop->op_ppaddr = &pp_assertbin;
+            argop->op_private = binoptype;
+            *out = argop;
+        }
+        else {
+            *out = newUNOP_CUSTOM(&pp_assert, 0, argop);
+        }
     }
     else {
         // do nothing.
@@ -55,6 +109,11 @@ BOOT:
   XopENTRY_set(&xop_assert, xop_desc, "assert");
   XopENTRY_set(&xop_assert, xop_class, OA_UNOP);
   Perl_custom_op_register(aTHX_ &pp_assert, &xop_assert);
+
+  XopENTRY_set(&xop_assertbin, xop_name, "assertbin");
+  XopENTRY_set(&xop_assertbin, xop_desc, "assert(binary)");
+  XopENTRY_set(&xop_assertbin, xop_class, OA_BINOP);
+  Perl_custom_op_register(aTHX_ &pp_assertbin, &xop_assertbin);
 
   register_xs_parse_keyword("assert", &hooks_assert, NULL);
 

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -24,6 +24,7 @@ subtest 'Test `assert` keyword' => sub {
     like dies { assert( 0 ) }, qr/\AAssertion failed \(0\)/;
     like dies { assert( '0' ) }, qr/\AAssertion failed \("0"\)/;
     like dies { assert( '' ) }, qr/\AAssertion failed \(""\)/;
+    like dies { assert( !1 ) }, qr/\AAssertion failed \(false\)/;
 };
 
 subtest 'Test `assert(binary)` keyword' => sub {
@@ -35,6 +36,8 @@ subtest 'Test `assert(binary)` keyword' => sub {
 
         like dies { assert( $x + $y == 100 ) },   qr/\AAssertion failed \(3 == 100\)/;
         like dies { assert( $x == 100 ) },        qr/\AAssertion failed \(1 == 100\)/;
+        like dies { assert( !$x == 100 ) },        qr/\AAssertion failed \(false == 100\)/;
+        like dies { assert( !!$x == 100 ) },        qr/\AAssertion failed \(true == 100\)/;
 
         my $message = 'hello';
         my $undef = undef;

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -52,8 +52,10 @@ subtest 'Test `assert(binary)` keyword' => sub {
         like dies { assert( $undef == 100 ) },    qr/\AAssertion failed \(got undef, expected 100\)/;
 
         like dies { assert( $message eq 'world' ) }, qr/\AAssertion failed \(got "hello", expected "world"\)/;
-        like dies { assert( $x eq 'world' ) },       qr/\AAssertion failed \(got 1, expected "world"\)/;
         like dies { assert( $undef eq 'world' ) },   qr/\AAssertion failed \(got undef, expected "world"\)/;
+
+        my $expected = $] >= 5.036 ? qr/\AAssertion failed \(got 1, expected "world"\)/ : qr/\AAssertion failed \(got/;
+        like dies { assert( $x eq 'world' ) }, $expected;
     };
 
     # Suppressed warnings, first string comparison by numeric eq, other undef comparison

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -34,23 +34,4 @@ subtest 'Test `assert` keyword' => sub {
 
 };
 
-subtest 'Test `assert` with Carp::Verbose' => sub {
-    subtest 'When Carp::Verbose is enabled' => sub {
-        my $error = dies {
-            local $Carp::Verbose = 1;
-            assert( 0 )
-        };
-        my @errors = split /\n/, $error;
-        ok @errors > 1;
-    };
-
-    subtest 'When Carp::Verbose is disabled' => sub {
-        my $error = dies {
-            assert ( 0 ) # Default is Carp::Verbose = 0
-        };
-        my @errors = split /\n/, $error;
-        is @errors, 1;
-    };
-};
-
 done_testing;

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -20,46 +20,63 @@ subtest 'Test `assert` keyword' => sub {
     ok lives { $hello->('world') };
     ok dies { $hello->(undef) };
 
-    like dies { assert( undef ) }, qr/\AAssertion failed \(got undef\)/;
-    like dies { assert( 0 ) }, qr/\AAssertion failed \(got 0\)/;
-    like dies { assert( '0' ) }, qr/\AAssertion failed \(got "0"\)/;
-    like dies { assert( '' ) }, qr/\AAssertion failed \(got ""\)/;
+    like dies { assert( undef ) }, qr/\AAssertion failed \(undef\)/;
+    like dies { assert( 0 ) }, qr/\AAssertion failed \(0\)/;
+    like dies { assert( '0' ) }, qr/\AAssertion failed \("0"\)/;
+    like dies { assert( '' ) }, qr/\AAssertion failed \(""\)/;
 };
 
 subtest 'Test `assert(binary)` keyword' => sub {
-    like dies {
-        assert( 1 == 0 );
-    }, qr/\AAssertion failed/;
 
-    ok lives {
-        assert( 1 == 1 );
+    subtest 'NUM_EQ' => sub {
+        my $x = 1;
+        my $y = 2;
+        ok lives { assert( $x + $y == 3 ) };
+
+        like dies { assert( $x + $y == 100 ) },   qr/\AAssertion failed \(3 == 100\)/;
+        like dies { assert( $x == 100 ) },        qr/\AAssertion failed \(1 == 100\)/;
+
+        my $message = 'hello';
+        my $undef = undef;
+
+        my $warnings = warnings {
+            like dies { assert( $message == 100 ) },  qr/\AAssertion failed \("hello" == 100\)/;
+            like dies { assert( $undef == 100 ) },    qr/\AAssertion failed \(undef == 100\)/;
+        };
+        # suppressed warnings
+        is scalar @$warnings, 2;
     };
 
-    my $x = 1;
-    my $y = 2;
-    ok lives { assert( $x + $y == 3 ) };
-
-    my $message = 'hello';
-    ok lives { assert( $message eq 'hello' ) };
-
-    my $undef = undef;
-
-    like dies { assert( $x + $y == 100 ) },   qr/\AAssertion failed \(got 3, expected 100\)/;
-    like dies { assert( $x == 100 ) },        qr/\AAssertion failed \(got 1, expected 100\)/;
-
-    my $warnings = warnings {
-        like dies { assert( $message == 100 ) },  qr/\AAssertion failed \(got "hello", expected 100\)/;
-        like dies { assert( $undef == 100 ) },    qr/\AAssertion failed \(got undef, expected 100\)/;
-
-        like dies { assert( $message eq 'world' ) }, qr/\AAssertion failed \(got "hello", expected "world"\)/;
-        like dies { assert( $undef eq 'world' ) },   qr/\AAssertion failed \(got undef, expected "world"\)/;
-
-        my $expected = $] >= 5.036 ? qr/\AAssertion failed \(got 1, expected "world"\)/ : qr/\AAssertion failed \(got/;
-        like dies { assert( $x eq 'world' ) }, $expected;
+    subtest 'NUM_NE' => sub {
+        my $x = 2;
+        ok lives { assert( $x != 1 ) };
+        like dies { assert( $x != 2 ) }, qr/\AAssertion failed \(2 != 2\)/;
     };
 
-    # Suppressed warnings, first string comparison by numeric eq, other undef comparison
-    is scalar @$warnings, 3;
+    subtest 'STR_EQ' => sub {
+        my $message = 'hello';
+
+        ok lives { assert( $message eq 'hello' ) };
+        like dies { assert( $message eq 'world' ) }, qr/\AAssertion failed \("hello" eq "world"\)/;
+
+        my $x = 1;
+        my $undef = undef;
+
+        my $got = $] >= 5.036 ? '1' : '"1"';
+        like dies { assert( $x eq 'world' ) }, qr/\AAssertion failed \($got eq "world"\)/;
+
+        my $warnings = warnings {
+            like dies { assert( $undef eq 'world' ) },   qr/\AAssertion failed \(undef eq "world"\)/;
+        };
+        # suppressed warnings
+        is scalar @$warnings, 1;
+    };
+
+    subtest 'STR_NE' => sub {
+        my $message = 'hello';
+        ok lives { assert( $message ne 'world' ) };
+        like dies { assert( $message ne 'hello' ) }, qr/\AAssertion failed \("hello" ne "hello"\)/;
+    };
 };
 
 done_testing;

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -25,13 +25,36 @@ subtest 'Test `assert` keyword' => sub {
         $hello->(undef);
     }, qr/\AAssertion failed/;
 
+
+};
+
+subtest 'Test `assert(binary)` keyword' => sub {
     like dies {
-        my $x = 1;
-        my $y = 2;
+        assert( 1 == 0 );
+    }, qr/\AAssertion failed/;
 
+    ok lives {
+        assert( 1 == 1 );
+    };
+
+    my $x = 1;
+    my $y = 2;
+
+    like dies {
         assert( $x + $y == 100 );
-    }, qr/\AAssertion failed/, 'assert block with multiple statements';
+    }, qr/\AAssertion failed/;
 
+    ok lives {
+        assert( $x + $y == 3 );
+    };
+
+    like dies {
+        assert( 'hello' eq 'world' );
+    }, qr/\AAssertion failed/;
+
+    ok lives {
+        assert( 'hello' eq 'hello' );
+    };
 };
 
 done_testing;

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -24,7 +24,9 @@ subtest 'Test `assert` keyword' => sub {
     like dies { assert( 0 ) }, qr/\AAssertion failed \(0\)/;
     like dies { assert( '0' ) }, qr/\AAssertion failed \("0"\)/;
     like dies { assert( '' ) }, qr/\AAssertion failed \(""\)/;
-    like dies { assert( !1 ) }, qr/\AAssertion failed \(false\)/;
+
+    my $false = $] >= 5.036 ? 'false' : '""';
+    like dies { assert( !1 ) }, qr/\AAssertion failed \($false\)/;
 };
 
 subtest 'Test `assert(binary)` keyword' => sub {
@@ -36,8 +38,11 @@ subtest 'Test `assert(binary)` keyword' => sub {
 
         like dies { assert( $x + $y == 100 ) },   qr/\AAssertion failed \(3 == 100\)/;
         like dies { assert( $x == 100 ) },        qr/\AAssertion failed \(1 == 100\)/;
-        like dies { assert( !$x == 100 ) },        qr/\AAssertion failed \(false == 100\)/;
-        like dies { assert( !!$x == 100 ) },        qr/\AAssertion failed \(true == 100\)/;
+
+        my $true = $] >= 5.036 ? 'true' : '"1"';
+        my $false = $] >= 5.036 ? 'false' : '""';
+        like dies { assert( !!$x == 100 ) },        qr/\AAssertion failed \($true == 100\)/;
+        like dies { assert( !$x == 100 ) },        qr/\AAssertion failed \($false == 100\)/;
 
         my $message = 'hello';
         my $undef = undef;

--- a/t/01_assert.t
+++ b/t/01_assert.t
@@ -4,16 +4,16 @@ use Syntax::Keyword::Assert;
 
 subtest 'Test `assert` keyword' => sub {
     like dies {
-        assert { 0 };
+        assert( 0 );
     }, qr/\AAssertion failed/;
 
     ok lives {
-        assert { 1 };
+        assert( 1 );
     };
 
     my $hello = sub {
         my ($message) = @_;
-        assert { defined $message };
+        assert( defined $message );
         return "Hello, $message!";
     };
 
@@ -26,11 +26,10 @@ subtest 'Test `assert` keyword' => sub {
     }, qr/\AAssertion failed/;
 
     like dies {
-        assert {
-            my $x = 1;
-            my $y = 2;
-            $x + $y == 100;
-        };
+        my $x = 1;
+        my $y = 2;
+
+        assert( $x + $y == 100 );
     }, qr/\AAssertion failed/, 'assert block with multiple statements';
 
 };
@@ -38,10 +37,8 @@ subtest 'Test `assert` keyword' => sub {
 subtest 'Test `assert` with Carp::Verbose' => sub {
     subtest 'When Carp::Verbose is enabled' => sub {
         my $error = dies {
-            assert {
-                local $Carp::Verbose = 1;
-                0;
-            }
+            local $Carp::Verbose = 1;
+            assert( 0 )
         };
         my @errors = split /\n/, $error;
         ok @errors > 1;
@@ -49,7 +46,7 @@ subtest 'Test `assert` with Carp::Verbose' => sub {
 
     subtest 'When Carp::Verbose is disabled' => sub {
         my $error = dies {
-            assert { 0 } # Default is Carp::Verbose = 0
+            assert ( 0 ) # Default is Carp::Verbose = 0
         };
         my @errors = split /\n/, $error;
         is @errors, 1;

--- a/t/02_assert_disabled.t
+++ b/t/02_assert_disabled.t
@@ -8,16 +8,16 @@ use Syntax::Keyword::Assert;
 
 subtest 'Test `assert` keyword when $ENV{PERL_ASSERT_ENABLED} is falsy' => sub {
     ok lives {
-        assert { 0 };
+        assert( 0 );
     };
 
     ok lives {
-        assert { 1 };
+        assert( 1 );
     };
 
     my $hello = sub {
         my ($message) = @_;
-        assert { defined $message };
+        assert( defined $message );
         return "Hello, $message!";
     };
 

--- a/t/03_unimport.t
+++ b/t/03_unimport.t
@@ -4,13 +4,13 @@ use Syntax::Keyword::Assert;
 
 subtest 'Test `unimport`' => sub {
     ok lives {
-        assert { 1 };
+        assert( 1 );
     };
 
     no Syntax::Keyword::Assert;
 
     ok dies {
-        assert { 1 };
+        assert( 1 );
     }, 'unimported assert';
 };
 

--- a/t/10-integration/Data-Checks.t
+++ b/t/10-integration/Data-Checks.t
@@ -10,11 +10,11 @@ use Data::Checks qw( Str );
 
 subtest 'Test `assert` with Data::Checks' => sub {
     ok lives {
-        assert { Str->check('hello') };
+        assert ( Str->check('hello') );
     };
 
     ok dies {
-        assert { Str->check({}) };
+        assert ( Str->check({}) );
     };
 };
 

--- a/t/10-integration/Data-Checks.t
+++ b/t/10-integration/Data-Checks.t
@@ -1,10 +1,6 @@
 use Test2::V0;
 use Test2::Require::Module 'Data::Checks', '0.09';
 
-BEGIN {
-    $ENV{PERL_STRICT} = 1;
-}
-
 use Syntax::Keyword::Assert;
 use Data::Checks qw( Str );
 

--- a/t/10-integration/Syntax-Operator-Is.t
+++ b/t/10-integration/Syntax-Operator-Is.t
@@ -12,11 +12,11 @@ use Data::Checks qw( Str );
 
 subtest 'Test `assert` with Syntax::Operator::Is' => sub {
     ok lives {
-        assert { 'hello' is_ Str };
+        assert ( 'hello' is_ Str );
     };
 
     ok dies {
-        assert { {} is_ Str };
+        assert ( {} is_ Str );
     };
 };
 

--- a/t/10-integration/Syntax-Operator-Is.t
+++ b/t/10-integration/Syntax-Operator-Is.t
@@ -2,10 +2,6 @@ use Test2::V0;
 use Test2::Require::Module 'Syntax::Operator::Is', '0.02';
 use Test2::Require::Module 'XS::Parse::Infix', '0.44';
 
-BEGIN {
-    $ENV{PERL_STRICT} = 1;
-}
-
 use Syntax::Keyword::Assert;
 use Syntax::Operator::Is is => { -as => "is_" };
 use Data::Checks qw( Str );

--- a/t/10-integration/Type-Tiny.t
+++ b/t/10-integration/Type-Tiny.t
@@ -1,10 +1,6 @@
 use Test2::V0;
 use Test2::Require::Module 'Type::Tiny', '2.000000';
 
-BEGIN {
-    $ENV{PERL_STRICT} = 1;
-}
-
 use Syntax::Keyword::Assert;
 use Types::Standard -types;
 

--- a/t/10-integration/Type-Tiny.t
+++ b/t/10-integration/Type-Tiny.t
@@ -10,11 +10,11 @@ use Types::Standard -types;
 
 subtest 'Test `assert` with Type::Tiny' => sub {
     ok lives {
-        assert { Str->check('hello') };
+        assert ( Str->check('hello') );
     };
 
     ok dies {
-        assert { Str->check({}) };
+        assert ( Str->check({}) );
     };
 };
 

--- a/t/10-integration/signatures.t
+++ b/t/10-integration/signatures.t
@@ -3,10 +3,6 @@ use Test2::Require::Perl 'v5.36';
 
 use feature qw(signatures);
 
-BEGIN {
-    $ENV{PERL_STRICT} = 1;
-}
-
 use Syntax::Keyword::Assert;
 
 subtest 'Test `assert` with signatures' => sub {

--- a/t/10-integration/signatures.t
+++ b/t/10-integration/signatures.t
@@ -12,7 +12,7 @@ use Syntax::Keyword::Assert;
 subtest 'Test `assert` with signatures' => sub {
 
     my sub hello($name) {
-        assert { defined $name };
+        assert ( defined $name );
         return "Hello, $name!";
     }
 

--- a/t/99_synopsis.t
+++ b/t/99_synopsis.t
@@ -1,0 +1,9 @@
+use Test2::V0;
+
+use Syntax::Keyword::Assert;
+
+my $name = 'Alice';
+my $e = dies { assert( $name eq 'Bob' ) };
+like $e, qr/Assertion failed \("Alice" eq "Bob"\)/;
+
+done_testing;


### PR DESCRIPTION
This pull request provides these error messages:

```perl
assert ($a == 1);
# => Assertion failed. got: $a, expected: 1
```