### PR TITLE
Add unreachable croak

### DIFF
--- a/hax/sv_numcmp.c.inc
+++ b/hax/sv_numcmp.c.inc
@@ -53,6 +53,8 @@ static int S_sv_numcmp_flags(pTHX_ SV *lhs, SV *rhs, U32 flags)
       }
       case 3: /* UV <=> UV */
         return (SvUVX(lhs) > SvUVX(rhs)) - (SvUVX(lhs) < SvUVX(rhs));
+      default:
+        croak("unreachable");
     }
   }
   else {


### PR DESCRIPTION
This pull request fixed the following warnings:

% minil test
...
> ax/sv_numcmp.c.inc:64:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
1 warning generated.